### PR TITLE
Adjust Player Name Z-Levels

### DIFF
--- a/scenes/characters/player.gd
+++ b/scenes/characters/player.gd
@@ -34,7 +34,7 @@ func give_control_to_the_proper_client() -> void:
 	var peer_id = get_peer_id()
 	set_multiplayer_authority(peer_id) # Setting the multiplayer authority tells the engine which peer is in charge of this node
 	$Username.set_multiplayer_authority(1) # Setting the multiplayer authority to 1 lets the server be in charge of the label
-	
+
 ## Adds a camera 2D to this player
 func follow_it_with_a_camera() -> void:
 	var camera = ZOOMING_CAMERA_FACTORY.instantiate()

--- a/scenes/characters/player.tscn
+++ b/scenes/characters/player.tscn
@@ -32,6 +32,7 @@ shape = SubResource("RectangleShape2D_55toe")
 replication_config = SubResource("SceneReplicationConfig_o4u40")
 
 [node name="Username" type="Label" parent="."]
+z_index = 50
 offset_left = -39.0
 offset_top = 26.0
 offset_right = 41.0

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -7,7 +7,7 @@
 [ext_resource type="PackedScene" uid="uid://b571wyts626or" path="res://scenes/ui/options_menu/options_menu.tscn" id="3_f7tt1"]
 [ext_resource type="PackedScene" uid="uid://cle6alqm1uehe" path="res://scenes/components/multiplayer_connection/multiplayer_connection.tscn" id="3_qakxp"]
 [ext_resource type="PackedScene" uid="uid://bnmgufd7m2y27" path="res://scenes/ui/credits_menu/credits_menu.tscn" id="4_b63uw"]
-[ext_resource type="FontFile" uid="uid://d161yog70v2t" path="res://assets/fonts/nunito/Nunito.ttf" id="5_6g78f"]
+[ext_resource type="FontFile" uid="uid://dcdq78lly44xv" path="res://assets/fonts/nunito/Nunito.ttf" id="5_6g78f"]
 [ext_resource type="Script" path="res://scenes/kill_server.gd" id="6_6uen7"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_1aih0"]


### PR DESCRIPTION
Simply updates the Z-Level of the Player's username label to an absurdly high value. Should prevent name tags from being hidden by contributed assets.